### PR TITLE
Add display for request/response headers fixes #16

### DIFF
--- a/fake/fake-extension.js
+++ b/fake/fake-extension.js
@@ -436,6 +436,17 @@ var generateMvcRequest = (function() {
             payload.requestPath = source.path;
             payload.requestQueryString = source.queryString;
             payload.requestUrl = 'http://localhost:5000' + source.path + defaultOrEmpty(source.queryString);
+            payload.requestHeaders = {
+                'Server': 'GitHub.com',
+                'Date': 'Mon, 02 Nov 2015 06:39:26 GMT',
+                'Content-Type': 'text/html; charset=utf-8',
+                'Transfer-Encoding': 'chunked',
+                'Status': '200 OK',
+                'Cache-Control': 'no-cache',
+                'Strict-Transport-Security': 'max-age=31536000; includeSubdomains; preload',
+                'Vary': 'Accept-Encoding',
+                'Content-Encoding': 'gzip'
+            }; 
             
             MessageGenerator.support.beforeTimings('request', payload, source.dateTime);
             
@@ -451,6 +462,15 @@ var generateMvcRequest = (function() {
             payload.requestPath = source.path;
             payload.requestQueryString = source.queryString;
             payload.requestUrl = 'http://localhost:5000' + source.path + defaultOrEmpty(source.queryString);
+            payload.responseHeaders = {
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+                'Accept-Encoding': 'gzip, deflate, sdch',
+                'Accept-Language': 'en-US,en;q=0.8',
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive',
+                'Host': 'github.com',
+                'Pragma': 'no-cache'
+            };
              
             MessageGenerator.support.afterTimings('response', payload, source.duration, source.dateTime);
             

--- a/src/request/components/request-detail-panel-execution.jsx
+++ b/src/request/components/request-detail-panel-execution.jsx
@@ -70,6 +70,28 @@ var RequestHeaders = React.createClass({
     }
 });
 
+var RequestHeadersSummary = React.createClass({
+    render: function() {
+        return (
+            <div>
+                <div className="tab-section tab-section-execution-headers">
+                    <div className="flex flex-row flex-inherit tab-section-header">
+                        <div className="tab-title col-10">{this.props.title}</div>
+                    </div>
+                    <div className="tab-section-boxing tab-section-listing">
+                        {_.map(this.props.headers, function(value, key) {
+                            return (<section className="flex flex-row">
+                                    <div className="col-2">{key}</div>
+                                    <div className="col-8">{value}</div>
+                                </section>);
+                        })}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+});
+
 var CommandItem = React.createClass({
     getInitialState: function() {
         return { show: false };
@@ -332,10 +354,20 @@ module.exports = React.createClass({
                 postCommands = <CommandList beforeExecuteCommandMessages={beforeExecuteCommandMessages} afterExecuteCommandMessages={afterExecuteCommandMessages} beginMessage={afterActionResultMessage} endMessage={endRequestMessage} isRoot={true} />            
             }
             
+            //process headers
+            var requestHeaders = null;
+            if (beginRequestPayload && beginRequestPayload.requestHeaders) {
+                requestHeaders = <RequestHeadersSummary title="Request Headers" headers={beginRequestPayload.requestHeaders} />;
+            }
+            var responseHeaders = null;
+            if (endRequestPayload && endRequestPayload.responseHeaders) {
+                responseHeaders = <RequestHeadersSummary title="Response Headers" headers={endRequestPayload.responseHeaders} />;
+            }
+            
             content = (
                 <div>
                     <div className="tab-section text-minor">Execution on Server</div>
-                    {preCommands}{route}{action}{view}{postCommands}
+                    {requestHeaders}{preCommands}{route}{action}{view}{postCommands}{responseHeaders}
                 </div>
             );
         }   


### PR DESCRIPTION
Initial cut of adding the request/response headers to the execution screen.

<img width="500" alt="screen shot 2016-02-25 at 6 29 06 pm" src="https://cloud.githubusercontent.com/assets/585619/13341471/ee55c7f2-dbed-11e5-9b84-bcf460d93b30.png">

Now awaiting feedback on what the design is - @nikmd23 