### PR TITLE
[Middleware] Adds routing metadata (if any) to middleware execution flow.

### DIFF
--- a/fake/fake-extension.js
+++ b/fake/fake-extension.js
@@ -198,15 +198,27 @@ var seedMvcActions = (function() {
                         action: 'Index',
                         route: generate.common.route('home', 'index', null),
                         preActivities: [
-                            { access: 'middleware-start', correlationId: '123456789', name: 'logger' },
-                            { access: 'middleware-end', correlationId: '123456789', name: 'logger', result: 'next' },
-                            { access: 'middleware-start', correlationId: '234567891', name: 'queryParser' },
+                            { access: 'middleware-start', name: 'query', paths: ['/'] },
+                            { access: 'middleware-end', name: 'query', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'expressInit', paths: ['/'] },
+                            { access: 'middleware-end', name: 'expressInit', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'logger', paths: ['/'] },
+                            { access: 'middleware-end', name: 'logger', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'jsonParser', paths: ['/'] },
+                            { access: 'middleware-end', name: 'jsonParser', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'urlencodedParser', paths: ['/'] },
+                            { access: 'middleware-end', name: 'urlencodedParser', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'cookieParser', paths: ['/'] },
+                            { access: 'middleware-end', name: 'cookieParser', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'serveStatic', paths: ['/'] },
+                            { access: 'middleware-end', name: 'serveStatic', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'router', paths: ['/'] },
+                            { access: 'middleware-end', name: 'router', paths: ['/'], result: 'error' },
+                            { access: 'middleware-start', name: 'router', paths: ['/users'] },
+                            { access: 'middleware-start', name: '<anonymous>', paths: ['/:id'], method: 'GET', params: { id: '1' } },
                             { access: 'mongo', type: 'data-mongodb-read', operation: 'toArray', query: {}, options: { find: 'MusicStore.AlbumCollection', limit: 0, skip: 0, query: {}, slaveOk: true, readPreference: { mode: 'primary' } }, connectionHost: 'localhost', connectionPort: 27017, database: 'MusicStore', collection: 'AlbumCollection' },
-                            { access: 'middleware-end', correlationId: '234567891', name: 'queryParser', result: 'next' },
-                            { access: 'middleware-start', correlationId: '345678912s', name: 'router' },
-                            { access: 'middleware-start', correlationId: '456789123', name: 'bodyParser' },
-                            { access: 'middleware-end', correlationId: '456789123', name: 'bodyParser', result: 'end' },
-                            { access: 'middleware-end', correlationId: '345678912', name: 'router', result: 'end' },
+                            { access: 'middleware-end', name: '<anonymous>', paths: ['/:id'], method: 'GET', params: { id: '1' }, result: 'end' },
+                            { access: 'middleware-end', name: 'router', paths: ['/users'], result: 'end' },
                             { access: 'SQL', operation: 'Select', target: 'Albums', affected: 1, command: 'SELECT TOP (2) \n[Extent1].[AlbumId] AS [AlbumId], \n[Extent1].[GenreId] AS [GenreId], \n[Extent1].[ArtistId] AS [ArtistId], \n[Extent1].[Title] AS [Title], \n[Extent1].[Price] AS [Price], \n[Extent1].[AlbumArtUrl] AS [AlbumArtUrl]\nFROM [dbo].[Albums] AS [Extent1]\nWHERE [Extent1].[AlbumId] = 1 /* @p0 */' },
                             { access: 'mongo', type: 'data-mongodb-read', operation: 'toArray', query: {}, options: { find: 'MusicStore.AlbumCollection', limit: 0, skip: 0, query: {}, slaveOk: true, readPreference: { mode: 'primary' } }, connectionHost: 'localhost', connectionPort: 27017, database: 'MusicStore', collection: 'AlbumCollection' }
                         ],
@@ -629,8 +641,10 @@ var generateMvcRequest = (function() {
             var message = this.createMessage('middleware-start', context);
             
             var payload = message.payload;
-            payload.correlationId = activity.correlationId;
             payload.name = activity.name;
+            payload.paths = activity.paths;
+            payload.method = activity.method;
+            payload.params = activity.params;
              
             // TODO: Bring in timing data when we have it
             //MessageGenerator.support.beforeTimings('command', payload, null);
@@ -641,8 +655,10 @@ var generateMvcRequest = (function() {
             var message = this.createMessage('middleware-end', context);
             
             var payload = message.payload;
-            payload.correlationId = activity.correlationId;
             payload.name = activity.name;
+            payload.paths = activity.paths;
+            payload.method = activity.method;
+            payload.params = activity.params;
             payload.result = activity.result;
             
             // TODO: Bring in timing data when we have it

--- a/src/request/components/request-detail-panel-execution.jsx
+++ b/src/request/components/request-detail-panel-execution.jsx
@@ -506,16 +506,85 @@ var MiddlewareComponents = React.createClass({
                 }
                 
                 var middlewareEndPayload = pair.endMessage.payload;
+                                                              
+                var method = null;
                 
-                // NOTE: This assumes result is human-readible (and English).                
-                var result = _.startCase(middlewareEndPayload.result);
+                if (middlewareEndPayload.method) {
+                    method = (
+                        <span className="text-minor">{middlewareEndPayload.method.toUpperCase()} &nbsp;</span>
+                    );
+                }
+
+                // NOTE: Since middleware is often attached to the "relative root" (i.e. '/') of any given route, 
+                //       we ignore paths === ['/'] to reduce the noise in the display and to emphasize non-root paths.
+
+                var paths = null;
+                
+                if (middlewareEndPayload.paths 
+                    && (middlewareEndPayload.paths.length > 1 || (middlewareEndPayload.paths.length == 1 && middlewareEndPayload.paths[0] != '/'))) {
+                    var pathsString;
+                    
+                    if (middlewareEndPayload.paths.length == 1) {
+                        pathsString = middlewareEndPayload.paths[0];
+                    }
+                    else {
+                        pathsString = '[' + middlewareEndPayload.paths.join(', ') + ']';
+                    }
+                    
+                    paths = (
+                        <span className="text-minor">{pathsString}</span>
+                    );
+                }
+                
+                var route = null;
+
+                if (method || paths) {
+                    route = (
+                        <section className="flex flex-row flex-inherit flex-base tab-section-item">
+                            <div className="col-8">{method}{paths}</div>
+                        </section>
+                    );
+                }
+
+                var params = null;
+                
+                if (middlewareEndPayload.params && middlewareEndPayload.name != 'router') {
+                    var paramComponents = _.map(middlewareEndPayload.params, function (value, key) {
+                        return (
+                            <div className="tab-section-details-item col-5">
+                                <div className="tab-section-details-key col-2"><div className="truncate">{key}:</div></div>
+                                <div className="tab-section-details-value col-8"><div className="truncate">{value}</div></div>
+                            </div>
+                        );
+                    });
+                    
+                    if (paramComponents.length > 0) {                        
+                        params = (
+                            <section className="flex flex-row flex-inherit flex-base tab-section-item">
+                                <div className="tab-section-details col-5">
+                                    {paramComponents}
+                                </div>
+                            </section>
+                        );
+                    }
+                }
+
+                var result = null;
+                
+                switch (middlewareEndPayload.result) {
+                    case 'next': result = /* Rightwards Arrow U+2192 */ String.fromCharCode(8594); break;
+                    case 'end': result = /* Rightwards Arrow to Bar U+21E5 */ String.fromCharCode(8677); break;                    
+                    case 'error': result = /* Exlamation Mark U+0021 */ String.fromCharCode(33); break;
+                }
 
                 return (
                         <div className="tab-section-boxing">
                             <section className="flex flex-row flex-inherit flex-base tab-section-item">
-                                <div className="col-8">{middlewareEndPayload.name} &nbsp; <span className="text-minor">({result})</span></div>
+                                <div className="col-8">{middlewareEndPayload.name} &nbsp; <span className="text-minor">{result}</span></div>
                                 <div className="tab-execution-timing">{middlewareEndPayload.duration} ms</div>
                             </section>
+                            {route}
+                            {params}
                             {nestedComponent}
                         </div>);
             };


### PR DESCRIPTION
If the Glimpse Agents includes routing metadata (route paths, HTTP method, and/or parameter values) when publishing middleware messages, the Client will now display it within the middleware flow of the Execution tab.

Also switches from using text to symbols for middleware results (i.e. `next`, `end`, and `error`) as it feels a little more streamlined and easier to read at a glance.

![screen shot 2016-03-22 at 10 17 36 am](https://cloud.githubusercontent.com/assets/6402946/13999873/a176302a-f0fb-11e5-81bf-df5bafdfac46.png)
