### PR TITLE
[Middleware] Now displays middleware display name and package link, if available.

### DIFF
--- a/fake/fake-extension.js
+++ b/fake/fake-extension.js
@@ -202,16 +202,16 @@ var seedMvcActions = (function() {
                             { access: 'middleware-end', name: 'query', paths: ['/'], result: 'next' },
                             { access: 'middleware-start', name: 'expressInit', paths: ['/'] },
                             { access: 'middleware-end', name: 'expressInit', paths: ['/'], result: 'next' },
-                            { access: 'middleware-start', name: 'logger', paths: ['/'] },
-                            { access: 'middleware-end', name: 'logger', paths: ['/'], result: 'next' },
-                            { access: 'middleware-start', name: 'jsonParser', paths: ['/'] },
-                            { access: 'middleware-end', name: 'jsonParser', paths: ['/'], result: 'next' },
-                            { access: 'middleware-start', name: 'urlencodedParser', paths: ['/'] },
-                            { access: 'middleware-end', name: 'urlencodedParser', paths: ['/'], result: 'next' },
-                            { access: 'middleware-start', name: 'cookieParser', paths: ['/'] },
-                            { access: 'middleware-end', name: 'cookieParser', paths: ['/'], result: 'next' },
-                            { access: 'middleware-start', name: 'serveStatic', paths: ['/'] },
-                            { access: 'middleware-end', name: 'serveStatic', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'logger', displayName: 'Morgan Logger', packageName: 'morgan', paths: ['/'] },
+                            { access: 'middleware-end', name: 'logger', displayName: 'Morgan Logger', packageName: 'morgan', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'jsonParser', displayName: 'JSON Body Parser', packageName: 'body-parser', paths: ['/'] },
+                            { access: 'middleware-end', name: 'jsonParser', displayName: 'JSON Body Parser', packageName: 'body-parser', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'urlencodedParser', displayName: 'URL-Encoded Body Parser', packageName: 'body-parser', paths: ['/'] },
+                            { access: 'middleware-end', name: 'urlencodedParser', displayName: 'URL-Encoded Body Parser', packageName: 'body-parser', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'cookieParser', displayName: 'Cookie Parser', packageName: 'cookie-parser', paths: ['/'] },
+                            { access: 'middleware-end', name: 'cookieParser', displayName: 'Cookie Parser', packageName: 'cookie-parser', paths: ['/'], result: 'next' },
+                            { access: 'middleware-start', name: 'serveStatic', displayName: 'Express Static File Server', packageName: 'express', paths: ['/'] },
+                            { access: 'middleware-end', name: 'serveStatic', displayName: 'Express Static File Server', packageName: 'express', paths: ['/'], result: 'next' },
                             { access: 'middleware-start', name: 'router', paths: ['/'] },
                             { access: 'middleware-end', name: 'router', paths: ['/'], result: 'error' },
                             { access: 'middleware-start', name: 'router', paths: ['/users'] },
@@ -642,6 +642,8 @@ var generateMvcRequest = (function() {
             
             var payload = message.payload;
             payload.name = activity.name;
+            payload.displayName = activity.displayName;
+            payload.packageName = activity.packageName;
             payload.paths = activity.paths;
             payload.method = activity.method;
             payload.params = activity.params;
@@ -656,6 +658,8 @@ var generateMvcRequest = (function() {
             
             var payload = message.payload;
             payload.name = activity.name;
+            payload.displayName = activity.displayName;
+            payload.packageName = activity.packageName;
             payload.paths = activity.paths;
             payload.method = activity.method;
             payload.params = activity.params;

--- a/src/request/components/request-detail-panel-execution.jsx
+++ b/src/request/components/request-detail-panel-execution.jsx
@@ -577,10 +577,20 @@ var MiddlewareComponents = React.createClass({
                     case 'error': result = /* Exlamation Mark U+0021 */ String.fromCharCode(33); break;
                 }
 
+                var name = middlewareEndPayload.displayName || middlewareEndPayload.name || '<anonymous>';
+
+                var packageLink = null;
+                
+                if (middlewareEndPayload.packageName) {
+                    var href = 'https://www.npmjs.com/package/' + middlewareEndPayload.packageName;
+                    
+                    packageLink = <a href={href} target="_blank">({middlewareEndPayload.packageName})</a>;
+                }
+
                 return (
                         <div className="tab-section-boxing">
                             <section className="flex flex-row flex-inherit flex-base tab-section-item">
-                                <div className="col-8">{middlewareEndPayload.name} &nbsp; <span className="text-minor">{result}</span></div>
+                                <div className="col-8">{name} &nbsp; {packageLink} &nbsp; <span className="text-minor">{result}</span></div>
                                 <div className="tab-execution-timing">{middlewareEndPayload.duration} ms</div>
                             </section>
                             {route}


### PR DESCRIPTION
Updates the Glimpse Client to display the middleware display name, if available.  If not, then the client will fallback to the middleware name, and finally, to `<anonymous>`.  The client will also display a link to the package to which the middleware belongs, if that is available.

![screen shot 2016-03-30 at 1 51 27 pm](https://cloud.githubusercontent.com/assets/6402946/14158311/4c657a30-f684-11e5-9b4b-60523a6d4c16.png)
