### PR TITLE
[Build] Create ZIP file of Client distribution files during CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,10 @@ install:
 - npm install
 script:
 - gulp ci
+deploy:
+  provider: releases
+  api_key:
+    secure: p0DliyK4lDpmS26BGzvpxVh1UtEexDMSMZlokUyJvI+LqBfI8US3pCQDeo8kjAXhMTRJMlqJxm7oll8eyq6VMOt37t8juuBAfNh1WCcJBfojhpbcRPJ7PIhAn8djpJQgPRBYPhBXVU0HAyiryyab6AZdBXxRvEzFPonPwayvWEtJeJdjgBsMdL4TMDd3BkrWZhwCXlIGvRY5pJMb3QiNwLQlxHJ8s8K3emXn4IcPyKbg0jJy6uLTo4kDXFL/MOwB7etYpJKxNlQBcjaa7P8+Zf/xdmhwW3kYgKAO2JGZGF0lF6oQ5EZAbWlCERlOZg4cJmRjM0QovO/L3NXkWj4RzKy+9/5A6vitu3R4GkbRq7sOO7obPXXozSFZHdRzcswsEvI2IlM4KNwRnLQw170FfsgpvaP15nvNVnzIgXP9B/J/rAfyM/4FCPUixs9gEtt4SnhTyoo/Ty6jaCTjPNBvCQbed0Qgb0LjxTfwzTKNl/ScGN1VVp5wieZFrFrqCHj4/GjDEr4ywgApRucqGi7W+0IZO5UbFnG5ksqnwmg+V5tmv3/2AtQytOXqsE7QeMneflM3/L3y3+O18Q30Ocqlbx6R1R+hSjYzZ2vmau3SyI4Lx7cP2VgD2NR68Wz8GdaLyOX1yYEZa7BQ+uuJ3miPPvYc7b+iM0PQthgvlloVd5I=
+  file: dist/client.zip
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+- 5.6
+install:
+- npm install
+script:
+- gulp ci

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Glimpse Client
 
+[![Build Status](https://travis-ci.org/Glimpse/Glimpse.Client.Prototype.svg?branch=master)](https://travis-ci.org/Glimpse/Glimpse.Client.Prototype)
+
 Glimpse provides real time diagnostics & insights to the fingertips of
 hundreds of thousands of developers daily. This is the client which runs in the
 browser, which the user interacts with and reports back to the server.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,4 +123,6 @@ gulp.task('prod', function (cb) {
     runSequence('build-prod', 'server', cb);
 });
 
+gulp.task('ci', ['build-dev'])
+
 gulp.task('default', ['dev']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ var gutil = require('gulp-util');
 var gif = require('gulp-if');
 // var filelog = require('gulp-filelog');  // NOTE: Used for debug
 var runSequence = require('run-sequence');
+var zip = require('gulp-zip');
 
 var settings = {
     index: __dirname + '/src/index.html',
@@ -74,12 +75,14 @@ gulp.task('bundle', function (cb) {
     }
 
 });
+
 gulp.task('pages', function () {
     return gulp.src(settings.index)
         .pipe(gif(RELEASE, htmlcompress()))
         .pipe(gulp.dest(settings.output))
         .pipe(gif(WATCH, browserSync.reload({ stream: true })));
 });
+
 gulp.task('assets', function () {
     return gulp.src(settings.assets)
         .pipe(gulp.dest(settings.output + '/assets'))
@@ -91,11 +94,13 @@ gulp.task('assets', function () {
 gulp.task('build', function (cb) {
     runSequence('pages', 'assets', 'bundle', cb);
 });
+
 gulp.task('build-dev', function (cb) {
     RELEASE = false;
     
     runSequence('build', cb);
 });
+
 gulp.task('build-prod', function (cb) {
     RELEASE = true;
     
@@ -117,12 +122,17 @@ gulp.task('dev', function (cb) {
 
     runSequence('build-dev', 'server', cb);
 });
+
 gulp.task('prod', function (cb) {
     WATCH = true;
 
     runSequence('build-prod', 'server', cb);
 });
 
-gulp.task('ci', ['build-dev'])
+gulp.task('ci', ['build-dev'], function () {
+    return gulp.src(['dist/**', '!dist/client.zip'])
+        .pipe(zip('client.zip'))
+        .pipe(gulp.dest('dist'));
+});
 
 gulp.task('default', ['dev']);

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-if": "1.2.5",
     "gulp-minify-html": "1.0.5",
     "gulp-util": "3.0.7",
+    "gulp-zip": "^3.2.0",
     "imports-loader": "0.6.4",
     "jscs": "2.9.0",
     "jshint": "2.9.1",


### PR DESCRIPTION
Updates the `ci` Gulp task to create a ZIP file "snapshot" of the distribution directory (minus the ZIP file itself, of course).  Also updates the Travis CI configuration to make the ZIP file part of a GitHub Release asset.  (This means that creating a release of the repo--i.e. tagging a commit--will cause Travis CI to build the repo, generate the ZIP file, then attach the ZIP file to the release for download).

This will then allow the Server and Electron repos to pull a given release snapshot during their build process, rather than have to actually copy the assets into their repositories.
