### PR TITLE
[Build] Turn off the fake server by default.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             DIAGNOSTICS: true,
-            FAKE_SERVER: true
+            FAKE_SERVER: false
         }),
         new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
         progressPlugin


### PR DESCRIPTION
Disables the fake server by default, which is likely to be the desired option for Client snapshot "releases" that are embedded into the Electron app or Server.
