### PR TITLE
[Packing] Client fonts using file-loader.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "del": "^2.2.0",
     "exports-loader": "0.6.2",
     "expose-loader": "0.7.1",
+    "file-loader": "^0.8.5",
     "gulp": "3.9.0",
     "gulp-filelog": "0.4.1",
     "gulp-if": "1.2.5",

--- a/src/request/components/request-view.scss
+++ b/src/request/components/request-view.scss
@@ -13,13 +13,13 @@
 // TODO: should probably be in shell 
 @font-face {
     font-family: 'Selawik';
-    src: url('~/assets/selawk.woff2') format('woff2'),
-         url('~/assets/selawk.woff') format('woff');
+    src: url('../../../assets/selawk.woff2') format('woff2'),
+         url('../../../assets/selawk.woff') format('woff');
 }
 @font-face {
     font-family: 'Selawik Light';
-    src: url('~/assets/selawkl.woff2') format('woff2'),
-         url('~/assets/selawkl.woff') format('woff');
+    src: url('../../../assets/selawkl.woff2') format('woff2'),
+         url('../../../assets/selawkl.woff') format('woff');
 }
 
 body, html {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,8 @@ module.exports = {
             { test: /\.css$/, loader: 'style!css!autoprefixer?browsers=last 2 version' },
             { test: /\.scss$/, loader: 'style!css!autoprefixer?browsers=last 2 version!sass?includePaths[]=' + (path.resolve(__dirname, './node_modules/bootstrap-sass/assets/stylesheets/')) },
             { test: /\.jsx$/, loader: 'jsx-loader?insertPragma=React.DOM' },
-            { test: /event-source/, loader: 'imports?this=>window!exports?EventSource=EventSource'}
+            { test: /event-source/, loader: 'imports?this=>window!exports?EventSource=EventSource'},
+            { test: /\.woff|\.woff2$/, loader: 'file-loader'}
         ]
     },
     plugins: [


### PR DESCRIPTION
The Client is currently not able to find its custom fonts because WebPack is placing them relative to the root of the web application.  Using a relative path requires a custom loader (e.g. `file-loader`), which seems to resolve the problem.

(Interestingly, this same trick doesn't seem to work for the HUD, perhaps due to the way it's injected into the host page.)
