### PR TITLE
Update CI build to report errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 node_js:
 - 5.6
 install:
-- npm install -g gulp
+- npm install -g gulp typings
 - npm install
+- typings install
 - cd _temp/hud && npm install && cd ../..
 script:
 - gulp ci

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,29 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+        {
+            "name": "Launch Build",
+            "type": "node",
+            "request": "launch",
+            "program": "/usr/local/bin/gulp",
+            "stopOnEntry": false,
+            "args": [
+                "build"
+            ],
+            "cwd": "${workspaceRoot}/",
+            "runtimeExecutable": null,
+            "runtimeArgs": [
+                "--nolazy"
+            ],
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "externalConsole": false,
+            "sourceMaps": false,
+            "outDir": null
+        },
 		{
-            "name": "Tests",
+            "name": "Launch Tests",
             "type": "node",
             "request": "launch",
             "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,15 @@ gulp.task('bundle', (cb) => {
     let started = false;
     const config = getBundleConfig();
     function processResult(err, stats) {
+        if (err) {
+            return cb(err);
+        }
+        
         gutil.log('Webpack\n' + stats.toString(config.log));
+
+        if (stats.hasErrors()) {
+            return cb(new Error('Webpack completed with errors.'))
+        }
 
         if (config.watch) {
             browserSync.reload(settings.entry);


### PR DESCRIPTION
I noticed that our CI builds were passing even when errors were being reported by Webpack (e.g. failing to find package definitions because no definitions were installed).  This change updates the Gulp `build` task to check for and propagate errors reported by Webpack.  Additionally, the CI configuration was updated to install `typings` prior to the build, which eliminates the existing (ignored) errors.
