### PR TITLE
Integrate Redux DevTools Chrome Extension Client

### DIFF
--- a/src/request/stores/RequestStore.ts
+++ b/src/request/stores/RequestStore.ts
@@ -2,4 +2,5 @@ import { requestReducer } from '../reducers/RequestReducer';
 
 import { createStore } from 'redux';
 
-export = createStore(requestReducer);
+export = createStore(requestReducer,
+    window.devToolsExtension && window.devToolsExtension());

--- a/src/request/stores/RequestStore.ts
+++ b/src/request/stores/RequestStore.ts
@@ -3,4 +3,4 @@ import { requestReducer } from '../reducers/RequestReducer';
 import { createStore } from 'redux';
 
 export = createStore(requestReducer,
-    window.devToolsExtension && window.devToolsExtension());
+    DEV_TOOLS && window.devToolsExtension && window.devToolsExtension());

--- a/typings-custom/redux-devtools-extension.d.ts
+++ b/typings-custom/redux-devtools-extension.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    devToolsExtension?: () => any;
+}

--- a/typings-custom/webpack.d.ts
+++ b/typings-custom/webpack.d.ts
@@ -1,0 +1,1 @@
+declare const DEV_TOOLS: boolean;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,8 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             DIAGNOSTICS: true,
-            FAKE_SERVER: false
+            FAKE_SERVER: false,
+            DEV_TOOLS: false
         }),
         new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
         progressPlugin


### PR DESCRIPTION
Integrates the [Redux DevTools Chrome Extension](https://github.com/zalmoxisus/redux-devtools-extension) with the Client (if installed).  The extension allows you to see `redux` actions and as they're dispatched and the resulting changes to application state as well as  "time travel" by rolling back/forward actions.

![screen shot 2016-05-31 at 3 32 06 pm](https://cloud.githubusercontent.com/assets/6402946/15692873/defa5edc-2745-11e6-981c-e3fc90f60377.png)

Note: this is the "lightweight" version integration that only works with the Chrome extension, but it prevents us from having to embed the tools within the Client itself.
