### PR TITLE
Display captured HTTP server request/response bodies

### DIFF
--- a/src/lib/StringUtilities.ts
+++ b/src/lib/StringUtilities.ts
@@ -1,3 +1,6 @@
+/**
+ * Converts strings of the form 'one-two-three' to 'One-Two-Three', also called 'train-case'.
+ */
 export function trainCase(value: string): string {
     if (value) {
         let newValue = '';

--- a/src/lib/StringUtilities.ts
+++ b/src/lib/StringUtilities.ts
@@ -1,0 +1,15 @@
+export function trainCase(value: string): string {
+    if (value) {
+        let newValue = '';
+
+        for(let i = 0; i < value.length; i++) {
+            newValue += (i === 0 || value[i - 1] === '-') 
+                ? value[i].toUpperCase()
+                : value[i];
+        }
+
+        return newValue;
+    }
+
+    return value;
+}

--- a/src/request/component-models/ComponentModel.ts
+++ b/src/request/component-models/ComponentModel.ts
@@ -1,7 +1,0 @@
-'use strict';
-
-import { IComponentModel } from './IComponentModel';
-
-export abstract class ComponentModel implements IComponentModel {
-    public abstract init(request);
-}

--- a/src/request/component-models/IComponentModel.ts
+++ b/src/request/component-models/IComponentModel.ts
@@ -1,5 +1,0 @@
-'use strict';
-
-export interface IComponentModel {
-    init(request): void;
-}

--- a/src/request/components/RequestDetailPanelLogging.tsx
+++ b/src/request/components/RequestDetailPanelLogging.tsx
@@ -8,8 +8,6 @@ import _ = require('lodash');
 import React = require('react');
 import Highlight = require('react-highlight');
 
-var store = require('../stores/RequestStore');
-
 class LogMessageObject extends React.Component<{ message: string }, {}> {
     public render() {
         return <div className='tab-logs-table-message-object'><Highlight className='javascript'>{this.props.message}</Highlight></div>;

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -68,7 +68,7 @@ export class Request extends React.Component<IRequestProps, {}> {
 
     private renderHeader(key: string, value: string) {
         return (
-            <li><span className='tab-request-header-key'>{trainCase(key)}: </span><span>{value}</span></li>
+            <li key={key}><span className='tab-request-header-key'>{trainCase(key)}: </span><span>{value}</span></li>
         );
     }
 

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -2,6 +2,7 @@ import { TabbedPanel } from './TabbedPanel';
 import { TabPanel } from './TabPanel';
 
 import _ = require('lodash');
+import Highlight = require('react-highlight');
 import React = require('react');
 
 interface IRequestUrlProps {
@@ -68,9 +69,11 @@ export class Request extends React.Component<IRequestProps, {}> {
         if (this.props.url && this.props.request && this.props.response) {
             content = (
                 <div className='tab-request'>
-                    { this.renderRequestResponse('tab-request-request', 'Request', this.props.request) }
-                    <div className='tab-request-separator' />
-                    { this.renderRequestResponse('tab-request-request', 'Response', this.props.response) }
+                    <div className='tab-request-response'>
+                        { this.renderRequestResponse('Request', this.props.request) }
+                        <div className='tab-request-separator' />
+                        { this.renderRequestResponse('Response', this.props.response) }
+                    </div>
                 </div>
             );
         }
@@ -81,16 +84,17 @@ export class Request extends React.Component<IRequestProps, {}> {
         return content;
     }
 
-    private renderRequestResponse(className: string, title: string, requestResponse: { body: string, headers: { [key: string]: string }}) {
+    private renderRequestResponse(title: string, requestResponse: { body: string, headers: { [key: string]: string }}) {
         return (
-            <div className='tab-request-request'>
-                <div>{title}</div>
+            <div className='tab-request-response-panel'>
+                <div className='tab-request-response-title'>{title}</div>
+                <br />
                 <TabbedPanel>
                     <TabPanel header='Headers'>
                         { this.renderHeaders(requestResponse.headers) }
                     </TabPanel>
                     <TabPanel header='Body'>
-                        <div>{requestResponse.body}</div>
+                        { this.renderBody(requestResponse.body) }
                     </TabPanel>
                 </TabbedPanel>
             </div>
@@ -110,6 +114,14 @@ export class Request extends React.Component<IRequestProps, {}> {
     private renderHeader(key: string, value: string) {
         return (
             <li><span className='tab-request-header-key'>{key}: </span><span>{value}</span></li>
+        );
+    }
+
+    private renderBody(body: string) {
+        return (
+            <div className='tab-request-body'>
+                <Highlight className=''>{body}</Highlight>
+            </div>
         );
     }
 }

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -1,21 +1,10 @@
 import { TabbedPanel } from './TabbedPanel';
 import { TabPanel } from './TabPanel';
+import { trainCase } from '../../lib/StringUtilities';
 
 import _ = require('lodash');
 import Highlight = require('react-highlight');
 import React = require('react');
-
-function trainCase(key: string): string {
-    let newKey = '';
-
-    for(let i = 0; i < key.length; i++) {
-        newKey += (i === 0 || key[i - 1] === '-') 
-            ? key[i].toUpperCase()
-            : key[i];
-    }
-
-    return newKey;
-}
 
 export interface IRequestProps {
     url: string;

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -5,50 +5,18 @@ import _ = require('lodash');
 import Highlight = require('react-highlight');
 import React = require('react');
 
-interface IRequestUrlProps {
-    url: string;
-}
+function trainCase(key: string): string {
+    let newKey = '';
 
-class RequestUrl extends React.Component<IRequestUrlProps, {}> {
-    public render() {
-        return (
-            <div>
-                <div className='tab-section tab-section-execution-url'>
-                    <div className='flex flex-row flex-inherit tab-section-header'>
-                        <div className='tab-title col-10'>Url</div>
-                    </div>
-                    <div>{this.props.url}</div>
-                </div>
-            </div>
-        );
+    for(let i = 0; i < key.length; i++) {
+        if (i === 0 || key[i - 1] === '-') {
+            newKey += key[i].toUpperCase();
+        } else {
+            newKey += key[i];
+        }
     }
-}
 
-interface IRequestHeadersProps {
-    headers: { [key: string]: string };
-    title: string;
-}
-
-class RequestHeaders extends React.Component<IRequestHeadersProps, {}> {
-    public render() {
-        return (
-            <div>
-                <div className='tab-section tab-section-execution-headers'>
-                    <div className='flex flex-row flex-inherit tab-section-header'>
-                        <div className='tab-title col-10'>{this.props.title}</div>
-                    </div>
-                    <div className='tab-section-listing'>
-                        {_.map(this.props.headers, function(value, key) {
-                            return (<section className='flex flex-row'>
-                                    <div className='col-2'>{key}</div>
-                                    <div className='col-8'>{value}</div>
-                                </section>);
-                        })}
-                    </div>
-                </div>
-            </div>
-        );
-    }
+    return newKey;
 }
 
 export interface IRequestProps {
@@ -113,7 +81,7 @@ export class Request extends React.Component<IRequestProps, {}> {
 
     private renderHeader(key: string, value: string) {
         return (
-            <li><span className='tab-request-header-key'>{key}: </span><span>{value}</span></li>
+            <li><span className='tab-request-header-key'>{trainCase(key)}: </span><span>{value}</span></li>
         );
     }
 

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -25,9 +25,9 @@ export class Request extends React.Component<IRequestProps, {}> {
             content = (
                 <div className='tab-request'>
                     <div className='tab-request-response'>
-                        { this.renderRequestResponse('Request', this.props.request) }
+                        { this.renderRequestResponse('Request', this.props.request.body, this.props.request.headers) }
                         <div className='tab-request-separator' />
-                        { this.renderRequestResponse('Response', this.props.response) }
+                        { this.renderRequestResponse('Response', this.props.response.body, this.props.response.headers) }
                     </div>
                 </div>
             );
@@ -39,17 +39,17 @@ export class Request extends React.Component<IRequestProps, {}> {
         return content;
     }
 
-    private renderRequestResponse(title: string, requestResponse: { body: string, headers: { [key: string]: string }}) {
+    private renderRequestResponse(title: string, body: string, headers: { [key: string]: string }) {
         return (
             <div className='tab-request-response-panel'>
                 <div className='tab-request-response-title'>{title}</div>
                 <br />
                 <TabbedPanel>
                     <TabPanel header='Headers'>
-                        { this.renderHeaders(requestResponse.headers) }
+                        { this.renderHeaders(headers) }
                     </TabPanel>
                     <TabPanel header='Body'>
-                        { this.renderBody(requestResponse.body) }
+                        { this.renderBody(body) }
                     </TabPanel>
                 </TabbedPanel>
             </div>

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -9,11 +9,9 @@ function trainCase(key: string): string {
     let newKey = '';
 
     for(let i = 0; i < key.length; i++) {
-        if (i === 0 || key[i - 1] === '-') {
-            newKey += key[i].toUpperCase();
-        } else {
-            newKey += key[i];
-        }
+        newKey += (i === 0 || key[i - 1] === '-') 
+            ? key[i].toUpperCase()
+            : key[i];
     }
 
     return newKey;

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -1,24 +1,8 @@
-'use strict';
-
-/*tslint:disable:no-var-requires */
-const messageProcessor = require('../util/request-message-processor');
-/*tslint:enable:no-var-requires */
+import { TabbedPanel } from './TabbedPanel';
+import { TabPanel } from './TabPanel';
 
 import _ = require('lodash');
 import React = require('react');
-
-const getPayloads = (function() {
-    const getItem = messageProcessor.getTypePayloadItem;
-
-    const options = {
-        'web-response': getItem,
-        'web-request': getItem
-    };
-
-    return function(request) {
-        return messageProcessor.getTypeStucture(request, options);
-    };
-})();
 
 interface IRequestUrlProps {
     url: string;
@@ -68,20 +52,25 @@ class RequestHeaders extends React.Component<IRequestHeadersProps, {}> {
 
 export interface IRequestProps {
     url: string;
-    requestHeaders: { [key: string]: string };
-    responseHeaders: { [key: string]: string };
+    request: {
+        body: string;
+        headers: { [key: string]: string }
+    };
+    response: {
+        body: string;
+        headers: { [key: string]: string };
+    };
 }
 
 export class Request extends React.Component<IRequestProps, {}> {
     public render() {
         let content;
-        if (this.props.url && this.props.requestHeaders && this.props.responseHeaders) {
+        if (this.props.url && this.props.request && this.props.response) {
             content = (
-                <div className='tab-content'>
-                    <div className='tab-section text-minor'>Web Request/Response</div>
-                    <RequestUrl url={this.props.url} />
-                    <RequestHeaders title='Request Headers' headers={this.props.requestHeaders} />
-                    <RequestHeaders title='Response Headers' headers={this.props.responseHeaders} />
+                <div className='tab-request'>
+                    { this.renderRequestResponse('tab-request-request', 'Request', this.props.request) }
+                    <div className='tab-request-separator' />
+                    { this.renderRequestResponse('tab-request-request', 'Response', this.props.response) }
                 </div>
             );
         }
@@ -90,5 +79,37 @@ export class Request extends React.Component<IRequestProps, {}> {
         }
 
         return content;
+    }
+
+    private renderRequestResponse(className: string, title: string, requestResponse: { body: string, headers: { [key: string]: string }}) {
+        return (
+            <div className='tab-request-request'>
+                <div>{title}</div>
+                <TabbedPanel>
+                    <TabPanel header='Headers'>
+                        { this.renderHeaders(requestResponse.headers) }
+                    </TabPanel>
+                    <TabPanel header='Body'>
+                        <div>{requestResponse.body}</div>
+                    </TabPanel>
+                </TabbedPanel>
+            </div>
+        );     
+    }
+
+    private renderHeaders(headers: { [key: string]: string}) {
+        return (
+            <div className='tab-request-headers'>
+                <ul>
+                    { _.map(headers, (value, key) => this.renderHeader(key, value)) }
+                </ul>
+            </div>
+        );
+    }
+
+    private renderHeader(key: string, value: string) {
+        return (
+            <li><span className='tab-request-header-key'>{key}: </span><span>{value}</span></li>
+        );
     }
 }

--- a/src/request/components/request-detail-content-panel-item-view.jsx
+++ b/src/request/components/request-detail-content-panel-item-view.jsx
@@ -15,16 +15,6 @@ module.exports = React.createClass({
             'active': this.props.isActive
         });
         
-        //var tabContent = requestTabController.resolveTab(name);
-
-        var componentModel;
-        
-        if (tab.componentModelFactory) {
-            componentModel = tab.componentModelFactory();
-            
-            componentModel.init(request);
-        }
-
-        return <div className={containerClass}><tab.component key={name} request={request} tab={tab} componentModel={componentModel}/></div>;
+        return <div className={containerClass}><tab.component key={name} request={request} tab={tab} /></div>;
     }
 });

--- a/src/request/components/request-view.scss
+++ b/src/request/components/request-view.scss
@@ -484,6 +484,47 @@ $tabbed-panel-border-color: #cccccc;
     table-layout: fixed;
 }
 
+.tab-request {
+    display: flex;
+    flex: none;
+    flex-direction: row;
+    height: 250px;
+}
+
+.tab-request-request {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+}
+
+.tab-request-separator {
+    background: gray;
+    flex: none;
+    width: 1px;
+}
+
+.tab-request-response {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+}
+
+.tab-request-headers {
+    > ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+
+        > li {
+            margin-bottom: 5px;
+        }
+    }
+}
+
+.tab-request-header-key {
+    font-weight: bold;
+}
+
 .tab-data {
     display: flex;
 }

--- a/src/request/components/request-view.scss
+++ b/src/request/components/request-view.scss
@@ -498,7 +498,7 @@ $tabbed-panel-border-color: #cccccc;
     display: flex;
     flex: none;
     flex-direction: row;
-    padding: 10px 40px 0px 40px;
+    padding: 10px 40px 10px 40px;
     width: 100%;
 }
 
@@ -515,9 +515,9 @@ $tabbed-panel-border-color: #cccccc;
 }
 
 .tab-request-separator {
-    background: gray;
+    background: #ccc;
     flex: none;
-    margin: 0px 5px 0px 5px;
+    margin: 0px 10px 0px 10px;
     width: 1px;
 }
 
@@ -538,7 +538,7 @@ $tabbed-panel-border-color: #cccccc;
 .tab-request-body {
     display: flex;
     overflow: auto;
-    
+
     .hljs {
         white-space: normal;
     }

--- a/src/request/components/request-view.scss
+++ b/src/request/components/request-view.scss
@@ -437,6 +437,7 @@ $tabbed-panel-border-color: #cccccc;
     background: #fafafa;
     border-bottom: 1px solid $tabbed-panel-border-color;
     display: flex;
+    flex: none;
     flex-direction: row;
     padding: 5px 30px 0px 30px;
 }
@@ -467,6 +468,7 @@ $tabbed-panel-border-color: #cccccc;
 }
 
 .tabbed-panel-selected {
+    flex: none;
     padding: 10px 5px 5px 5px;
 }
 
@@ -488,28 +490,40 @@ $tabbed-panel-border-color: #cccccc;
     display: flex;
     flex: none;
     flex-direction: row;
-    height: 250px;
+    width: 100%;
 }
 
-.tab-request-request {
+.tab-request-response {
+    box-sizing: border-box;
     display: flex;
-    flex: 1;
+    flex: none;
+    flex-direction: row;
+    padding: 10px 40px 0px 40px;
+    width: 100%;
+}
+
+.tab-request-response-panel {
+    display: flex;
+    flex: none;
     flex-direction: column;
+    width: 50%;
+}
+
+.tab-request-response-title {
+    font-family: 'Segoe UI', 'Selawik Semibold', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 175%;    
 }
 
 .tab-request-separator {
     background: gray;
     flex: none;
+    margin: 0px 5px 0px 5px;
     width: 1px;
 }
 
-.tab-request-response {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-}
-
 .tab-request-headers {
+    overflow: auto;
+
     > ul {
         list-style-type: none;
         margin: 0;
@@ -518,6 +532,15 @@ $tabbed-panel-border-color: #cccccc;
         > li {
             margin-bottom: 5px;
         }
+    }
+}
+
+.tab-request-body {
+    display: flex;
+    overflow: auto;
+    
+    .hljs {
+        white-space: normal;
     }
 }
 

--- a/src/request/reducers/RequestDetailRequestReducer.ts
+++ b/src/request/reducers/RequestDetailRequestReducer.ts
@@ -8,8 +8,14 @@ import { Action } from 'redux';
 
 const defaultState: IRequestDetailRequestState = {
     url: '',
-    requestHeaders: {},
-    responseHeaders: {}
+    request: {
+        body: '',
+        headers: {}
+    },
+    response: {
+        body: '',
+        headers: {}
+    }
 };
 
 // TODO: Consolidate this function into a utility function across reducers.
@@ -30,8 +36,14 @@ function updateRequestState(state: IRequestDetailRequestState, request): IReques
 
         return {
             url: requestMessage ? requestMessage.payload.url : undefined,
-            requestHeaders: requestMessage ? requestMessage.payload.headers : undefined,
-            responseHeaders: responseMessage ? responseMessage.payload.headers : undefined
+            request: {
+                body: requestMessage && requestMessage.payload.body && requestMessage.payload.body.content ? requestMessage.payload.body.content : '',
+                headers: requestMessage ? requestMessage.payload.headers : undefined
+            },
+            response: {
+                body: responseMessage && responseMessage.payload.body && responseMessage.payload.body.content ? responseMessage.payload.body.content : '',
+                headers: responseMessage ? responseMessage.payload.headers : undefined
+            }
         };
     }
 

--- a/src/request/stores/IRequestDetailRequestDetailsState.ts
+++ b/src/request/stores/IRequestDetailRequestDetailsState.ts
@@ -1,0 +1,4 @@
+export interface IRequestDetailRequestDetailsState {
+    body: string;
+    headers: { [key: string]: string }
+}

--- a/src/request/stores/IRequestDetailRequestState.ts
+++ b/src/request/stores/IRequestDetailRequestState.ts
@@ -1,5 +1,7 @@
+import { IRequestDetailRequestDetailsState } from './IRequestDetailRequestDetailsState';
+
 export interface IRequestDetailRequestState {
     url: string;
-    requestHeaders: { [key: string]: string };
-    responseHeaders: { [key: string]: string };
+    request: IRequestDetailRequestDetailsState;
+    response: IRequestDetailRequestDetailsState;
 }

--- a/test/lib/StringUtilities.spec.ts
+++ b/test/lib/StringUtilities.spec.ts
@@ -1,0 +1,71 @@
+import { trainCase } from '../../src/lib/StringUtilities';
+
+import * as chai from 'chai';
+
+const should = chai.should();
+
+describe('StringUtilities', () => {
+    describe('#trainCase', () => {
+        it('should return undefined for an undefined value', () => {
+            const newValue = trainCase(undefined);
+
+            should.not.exist(newValue);
+        });
+
+        it('should return an empty string for an empty value', () => {
+            const newValue = trainCase('');
+
+            should.exist(newValue);
+            newValue.should.equal('');
+        });
+
+        it('should convert a value with a leading dash', () => {
+            const newValue = trainCase('-test');
+
+            should.exist(newValue);
+            newValue.should.equal('-Test');
+        });
+
+        it('should convert a value with a trailing dash', () => {
+            const newValue = trainCase('test-');
+
+            should.exist(newValue);
+            newValue.should.equal('Test-');
+        });
+
+        it('should convert a value with a middle dash', () => {
+            const newValue = trainCase('test-value');
+
+            should.exist(newValue);
+            newValue.should.equal('Test-Value');
+        });
+
+        it('should convert a value with double dashes', () => {
+            const newValue = trainCase('test--value');
+
+            should.exist(newValue);
+            newValue.should.equal('Test--Value');
+        });
+
+        it('should convert a value with no dashes', () => {
+            const newValue = trainCase('test');
+
+            should.exist(newValue);
+            newValue.should.equal('Test');
+        });
+
+        it('should return an already train-cased value', () => {
+            const newValue = trainCase('Test-Value');
+
+            should.exist(newValue);
+            newValue.should.equal('Test-Value');
+        });
+
+        it('should preserve existing case', () => {
+            const newValue = trainCase('tEsT-vaLuE');
+
+            should.exist(newValue);
+            newValue.should.equal('TEsT-VaLuE');
+        });
+    });
+});

--- a/test/lib/StringUtilities.spec.ts
+++ b/test/lib/StringUtilities.spec.ts
@@ -19,6 +19,13 @@ describe('StringUtilities', () => {
             newValue.should.equal('');
         });
 
+        it('should return a value with only a dash', () => {
+            const newValue = trainCase('-');
+
+            should.exist(newValue);
+            newValue.should.equal('-');
+        });
+
         it('should convert a value with a leading dash', () => {
             const newValue = trainCase('-test');
 
@@ -66,6 +73,20 @@ describe('StringUtilities', () => {
 
             should.exist(newValue);
             newValue.should.equal('TEsT-VaLuE');
+        });
+
+        it('should ignore non-alpha characters in value', () => {
+            const newValue = trainCase('1');
+
+            should.exist(newValue);
+            newValue.should.equal('1');
+        });
+
+        it('should ignore non-alpha characters with dashes in value', () => {
+            const newValue = trainCase('1-1');
+
+            should.exist(newValue);
+            newValue.should.equal('1-1');
         });
     });
 });

--- a/test/request/selectors/RequestDetailDataSelectors.spec.ts
+++ b/test/request/selectors/RequestDetailDataSelectors.spec.ts
@@ -22,8 +22,14 @@ describe('RequestDetailDataSelectors', () => {
                 },
                 request: {
                     url: '',
-                    requestHeaders: {},
-                    responseHeaders: {}
+                    request: {
+                        body: '',
+                        headers: {}
+                    },
+                    response: {
+                        body: '',
+                        headers: {}
+                    }
                 },
                 webServices: {
                     requests: {},

--- a/test/request/selectors/RequestDetailLoggingSelectors.spec.ts
+++ b/test/request/selectors/RequestDetailLoggingSelectors.spec.ts
@@ -23,8 +23,14 @@ describe('RequestDetailLoggingSelectors', () => {
                 },
                 request: {
                     url: '',
-                    requestHeaders: {},
-                    responseHeaders: {}
+                    request: {
+                        body: '',
+                        headers: {}
+                    },
+                    response: {
+                        body: '',
+                        headers: {}
+                    }
                 },
                 webServices: {
                     requests: {},


### PR DESCRIPTION
A quick refactoring of the Request tab to show any captured request/response bodies as well as to better conform to the latest UX (two columns with sub-tabs).

<img width="1015" alt="screen shot 2016-06-09 at 4 43 10 pm" src="https://cloud.githubusercontent.com/assets/6402946/15950169/47f76c14-2e61-11e6-98da-d8f3de57d68a.png">
