### PR TITLE
Update version numbers for Sprint 7

### DIFF
--- a/_temp/hud/package.json
+++ b/_temp/hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client.hud",
-  "version": "2.0.0.alpha.7",
+  "version": "2.0.0-alpha.7",
   "description": "The Javascript client that acts as an in browser viewer for the various Glimpse server backends",
   "main": "dist/hud.js",
   "scripts": {

--- a/_temp/hud/package.json
+++ b/_temp/hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client.hud",
-  "version": "2.0.0-dev",
+  "version": "0.7.0",
   "description": "The Javascript client that acts as an in browser viewer for the various Glimpse server backends",
   "main": "dist/hud.js",
   "scripts": {

--- a/_temp/hud/package.json
+++ b/_temp/hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client.hud",
-  "version": "0.7.0",
+  "version": "2.0.0.alpha.7",
   "description": "The Javascript client that acts as an in browser viewer for the various Glimpse server backends",
   "main": "dist/hud.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client",
-  "version": "0.7.0",
+  "version": "2.0.0.alpha.7",
   "description": "The JavaScript client that acts as a viewer for the various Glimpse server backends",
   "main": "dist/glimpse.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client",
-  "version": "2.0.0.alpha.7",
+  "version": "2.0.0-alpha.7",
   "description": "The JavaScript client that acts as a viewer for the various Glimpse server backends",
   "main": "dist/glimpse.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client",
-  "version": "2.0.0-dev",
+  "version": "0.7.0",
   "description": "The JavaScript client that acts as a viewer for the various Glimpse server backends",
   "main": "dist/glimpse.js",
   "repository": {


### PR DESCRIPTION
Note: as the Client is an existing product, we're going with `2.0.0-alpha.<sprint>` as its new versioning scheme rather than the `0.<sprint>.0` scheme used for the newer Glimpse packages.