### PR TITLE
Highlight request/response bodies based on content type

### DIFF
--- a/fake/fake-extension.js
+++ b/fake/fake-extension.js
@@ -141,6 +141,10 @@ var seedMvcActions = (function() {
 
                     return {
                         headers: generate.common.headers('localhost:3000', 'text/html'),
+                        body: {
+                            request: '<html><body><div className="request">Request</div></body></html>',
+                            response: '<html><body><div className="response">Response</div></body></html>' 
+                        },
                         path: '/Store/Browse',
                         query: '?Genre=' + genre,
                         controller: 'Store',
@@ -248,7 +252,11 @@ var seedMvcActions = (function() {
                 },
                 cart: function() {
                     return {
-                        headers: generate.common.headers('localhost:3000', 'text/html'),
+                        headers: generate.common.headers('localhost:3000', 'application/json'),
+                        body: {
+                            request: '{ "request": "value" }',
+                            response: '{ "response": "value" }' 
+                        },
                         path: '/ShoppingCart/',
                         controller: 'ShoppingCart',
                         action: 'Index',
@@ -494,6 +502,12 @@ var generateMvcRequest = (function() {
             payload.url = 'http://localhost:5000' + source.path + defaultOrEmpty(source.query);
             payload.method = source.method;
             payload.headers = source.headers.request;
+            
+            if (source.body && source.body.request) {
+                payload.body = {
+                    content: source.body.request
+                }
+            }
 
             MessageGenerator.support.beforeTimings('', payload, source.dateTime);
 
@@ -507,6 +521,12 @@ var generateMvcRequest = (function() {
             payload.statusCode = source.statusCode;
             payload.statusText = source.statusText;
             payload.headers = source.headers.response;
+
+            if (source.body && source.body.response) {
+                payload.body = {
+                    content: source.body.response
+                }
+            }
 
             MessageGenerator.support.afterTimings('', payload, source.duration, source.dateTime);
 

--- a/src/lib/modules/glimpse-highlight.js
+++ b/src/lib/modules/glimpse-highlight.js
@@ -3,8 +3,11 @@ require('../../../node_modules/highlight.js/styles/vs.css');
 var hljs = require('../../../node_modules/highlight.js/lib/highlight.js');
 
 hljs.registerLanguage('cs', require('../../../node_modules/highlight.js/lib/languages/cs'));
+hljs.registerLanguage('css', require('../../../node_modules/highlight.js/lib/languages/css'));
 hljs.registerLanguage('sql', require('../../../node_modules/highlight.js/lib/languages/sql'));
 hljs.registerLanguage('javascript', require('../../../node_modules/highlight.js/lib/languages/javascript'));
 hljs.registerLanguage('json', require('../../../node_modules/highlight.js/lib/languages/json'));
+hljs.registerLanguage('livescript', require('../../../node_modules/highlight.js/lib/languages/livescript'));
+hljs.registerLanguage('xml', require('../../../node_modules/highlight.js/lib/languages/xml'));
 
 module.exports = hljs;

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -2,6 +2,8 @@ import { TabbedPanel } from './TabbedPanel';
 import { TabPanel } from './TabPanel';
 import { trainCase } from '../../lib/StringUtilities';
 
+import requestConverter = require('../repository/converter/request-converter');
+
 import _ = require('lodash');
 import Highlight = require('react-highlight');
 import React = require('react');
@@ -49,7 +51,7 @@ export class Request extends React.Component<IRequestProps, {}> {
                         { this.renderHeaders(headers) }
                     </TabPanel>
                     <TabPanel header='Body'>
-                        { this.renderBody(body) }
+                        { this.renderBody(body, headers) }
                     </TabPanel>
                 </TabbedPanel>
             </div>
@@ -72,11 +74,34 @@ export class Request extends React.Component<IRequestProps, {}> {
         );
     }
 
-    private renderBody(body: string) {
+    private renderBody(body: string, headers: { [key: string]: string }) {
+        const contentType = this.getContentTypeFromHeaders(headers);
+        const highlightClassName = this.getHighlightClassNameForContentType(contentType);
+
         return (
             <div className='tab-request-body'>
-                <Highlight className=''>{body}</Highlight>
+                <Highlight className={highlightClassName}>{body}</Highlight>
             </div>
         );
+    }
+
+    private getContentTypeFromHeaders(headers: { [key: string]: string }): string {
+        let contentType = undefined;
+
+        _.forEach(headers, (value, key) => {
+            if (key.toLowerCase() === 'content-type') {
+                contentType = value;
+                
+                return false;
+            }
+        });
+
+        return contentType;
+    }
+
+    private getHighlightClassNameForContentType(contentType: string): string {
+        const category = requestConverter.getContentTypeCategory(contentType);
+
+        return (category && category.highlight) || '';
     }
 }

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -12,10 +12,12 @@ export interface IRequestProps {
     url: string;
     request: {
         body: string;
+        contentType: string;
         headers: { [key: string]: string }
     };
     response: {
         body: string;
+        contentType: string;
         headers: { [key: string]: string };
     };
 }
@@ -27,9 +29,9 @@ export class Request extends React.Component<IRequestProps, {}> {
             content = (
                 <div className='tab-request'>
                     <div className='tab-request-response'>
-                        { this.renderRequestResponse('Request', this.props.request.body, this.props.request.headers) }
+                        { this.renderRequestResponse('Request', this.props.request.body, this.props.request.contentType, this.props.request.headers) }
                         <div className='tab-request-separator' />
-                        { this.renderRequestResponse('Response', this.props.response.body, this.props.response.headers) }
+                        { this.renderRequestResponse('Response', this.props.response.body, this.props.response.contentType, this.props.response.headers) }
                     </div>
                 </div>
             );
@@ -41,7 +43,7 @@ export class Request extends React.Component<IRequestProps, {}> {
         return content;
     }
 
-    private renderRequestResponse(title: string, body: string, headers: { [key: string]: string }) {
+    private renderRequestResponse(title: string, body: string, contentType: string, headers: { [key: string]: string }) {
         return (
             <div className='tab-request-response-panel'>
                 <div className='tab-request-response-title'>{title}</div>
@@ -51,7 +53,7 @@ export class Request extends React.Component<IRequestProps, {}> {
                         { this.renderHeaders(headers) }
                     </TabPanel>
                     <TabPanel header='Body'>
-                        { this.renderBody(body, headers) }
+                        { this.renderBody(body, contentType) }
                     </TabPanel>
                 </TabbedPanel>
             </div>
@@ -74,8 +76,7 @@ export class Request extends React.Component<IRequestProps, {}> {
         );
     }
 
-    private renderBody(body: string, headers: { [key: string]: string }) {
-        const contentType = this.getContentTypeFromHeaders(headers);
+    private renderBody(body: string, contentType: string) {
         const highlightClassName = this.getHighlightClassNameForContentType(contentType);
 
         return (
@@ -83,20 +84,6 @@ export class Request extends React.Component<IRequestProps, {}> {
                 <Highlight className={highlightClassName}>{body}</Highlight>
             </div>
         );
-    }
-
-    private getContentTypeFromHeaders(headers: { [key: string]: string }): string {
-        let contentType = undefined;
-
-        _.forEach(headers, (value, key) => {
-            if (key.toLowerCase() === 'content-type') {
-                contentType = value;
-                
-                return false;
-            }
-        });
-
-        return contentType;
     }
 
     private getHighlightClassNameForContentType(contentType: string): string {

--- a/src/request/containers/RequestDetailPanelRequestContainer.ts
+++ b/src/request/containers/RequestDetailPanelRequestContainer.ts
@@ -1,10 +1,24 @@
-import { getRequest } from '../selectors/RequestDetailRequestSelectors';
+import { getRequest, getRequestContentType, getResponseContentType } from '../selectors/RequestDetailRequestSelectors';
 import { Request } from '../components/RequestDetailPanelRequest';
 
 import { connect } from 'react-redux';
 
 function mapStateToProps(state) {
-    return getRequest(state);
+    const request = getRequest(state);
+
+    return {
+        url: request.url,
+        request: {
+            body: request.request.body,
+            contentType: getRequestContentType(state),
+            headers: request.request.headers
+        },
+        response: {
+            body: request.response.body,
+            contentType: getResponseContentType(state),
+            headers: request.response.headers
+        }
+    }
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/request/repository/converter/request-converter.d.ts
+++ b/src/request/repository/converter/request-converter.d.ts
@@ -1,0 +1,10 @@
+export function getContentTypeCategory(contentType: string): {
+    data?: boolean;
+    document?: boolean;
+    font?: boolean;
+    highlight?: string;
+    image?: boolean;
+    script?: boolean;
+    stylesheet?: boolean;
+    texttrack?: boolean;
+};

--- a/src/request/repository/converter/request-converter.js
+++ b/src/request/repository/converter/request-converter.js
@@ -8,13 +8,13 @@ var _strategies = [];
 
 var getContentTypeCategory = (function() {
     var listing = {
-        'text/html':                   {'document': true},
+        'text/html':                   {'document': true, 'highlight': 'xml'},
         'text/plain':                  {'document': true},
-        'application/xhtml+xml':       {'document': true},
-        'text/xml':                    {'data': true},
-        'application/json':            {'data': true},
-        'text/css':                    {'stylesheet': true},
-        'text/xsl':                    {'stylesheet': true},
+        'application/xhtml+xml':       {'document': true, 'highlight': 'xml'},
+        'text/xml':                    {'data': true, 'highlight': 'xml'},
+        'application/json':            {'data': true, 'highlight': 'json'},
+        'text/css':                    {'stylesheet': true, 'highlight': 'css'},
+        'text/xsl':                    {'stylesheet': true, 'highlight': 'xml'},
         'image/jpg':                   {'image': true},
         'image/jpeg':                  {'image': true},
         'image/pjpeg':                 {'image': true},
@@ -39,16 +39,16 @@ var getContentTypeCategory = (function() {
         'application/x-font-type1':    {'font': true},
         'application/x-font-ttf':      {'font': true},
         'application/x-truetype-font': {'font': true},
-        'text/javascript':             {'script': true},
-        'text/ecmascript':             {'script': true},
-        'application/javascript':      {'script': true},
-        'application/ecmascript':      {'script': true},
-        'application/x-javascript':    {'script': true},
-        'text/javascript1.1':          {'script': true},
-        'text/javascript1.2':          {'script': true},
-        'text/javascript1.3':          {'script': true},
-        'text/jscript':                {'script': true},
-        'text/livescript':             {'script': true},
+        'text/javascript':             {'script': true, 'highlight': 'javascript'},
+        'text/ecmascript':             {'script': true, 'highlight': 'javascript'},
+        'application/javascript':      {'script': true, 'highlight': 'javascript'},
+        'application/ecmascript':      {'script': true, 'highlight': 'javascript'},
+        'application/x-javascript':    {'script': true, 'highlight': 'javascript'},
+        'text/javascript1.1':          {'script': true, 'highlight': 'javascript'},
+        'text/javascript1.2':          {'script': true, 'highlight': 'javascript'},
+        'text/javascript1.3':          {'script': true, 'highlight': 'javascript'},
+        'text/jscript':                {'script': true, 'highlight': 'javascript'},
+        'text/livescript':             {'script': true, 'highlight': 'livescript'},
         'text/vtt':                    {'texttrack': true},
     };
     
@@ -226,7 +226,8 @@ module.exports = {
         });  
         
         return didUpdate;
-    }
+    },
+    getContentTypeCategory: getContentTypeCategory
 };
 
 // TODO: Need to come up with a better self registration process

--- a/src/request/selectors/RequestDetailRequestSelectors.ts
+++ b/src/request/selectors/RequestDetailRequestSelectors.ts
@@ -1,3 +1,33 @@
 import { IRequestState } from '../stores/IRequestState';
 
+import { createSelector } from 'reselect';
+
+import * as _ from 'lodash';
+
 export const getRequest = (state: IRequestState) => state.detail.request;
+
+function getContentTypeFromHeaders(headers: { [key: string]: string }): string {
+    let contentType = undefined;
+
+    _.forEach(headers, (value, key) => {
+        if (key.toLowerCase() === 'content-type') {
+            contentType = value;
+            
+            return false;
+        }
+    });
+
+    return contentType;
+}
+
+export const getRequestContentType = createSelector(
+    getRequest,
+    request => {
+        return getContentTypeFromHeaders(request.request.headers);
+    });
+
+export const getResponseContentType = createSelector(
+    getRequest,
+    request => {
+        return getContentTypeFromHeaders(request.response.headers);
+    });


### PR DESCRIPTION
A small change to the request/response Body sub-tab to highlight bodies based on the `Content-Type` header (e.g. use JSON syntax highlighting if the header indicates `application/json`).  Highlighting is done only for a set of well-known content types (easily added to as needed).

![screen shot 2016-06-27 at 11 10 52 am](https://cloud.githubusercontent.com/assets/6402946/16390521/0ebd1e58-3c58-11e6-8f85-75ed36a3833c.png)
