### PR TITLE
Replace lambda with anonymous function.

### DIFF
--- a/src/request/components/request-view.jsx
+++ b/src/request/components/request-view.jsx
@@ -13,8 +13,9 @@ module.exports = React.createClass({
     render: function () {
         return (
             <ReactRedux.Provider store={store}>
-                {
-                    () => (
+            {
+                function () {
+                    return (
                         <div className="request-holder application-section-group">
                             <div className="request-user-section application-section">
                                 <div className="request-holder-content">
@@ -32,9 +33,10 @@ module.exports = React.createClass({
                                 </div>
                             </div>
                             <Detail />
-                        </div> 
-                    )
+                        </div>
+                    );
                 }
+            } 
             </ReactRedux.Provider>
         );
     }


### PR DESCRIPTION
Fix issue with the Client not able to load in Safari due to use of lambda function.  It appears that we aren't yet using Babel in the existing Client's Webpack build process and Safari v9 doesn't yet support lambdas (but v10 does).