### PR TITLE
Resolve various F12 Tools and VS Code warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": false
+}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "style-loader": "^0.13.0",
     "superagent-mocker": "^0.4.0",
     "ts-loader": "^0.8.1",
+    "tslint": "^3.13.0",
     "typescript": "^1.8.9",
     "typings": "^1.0.2",
     "walk": "^2.3.9",

--- a/src/request/components/RequestDetailPanelLogging.tsx
+++ b/src/request/components/RequestDetailPanelLogging.tsx
@@ -17,7 +17,7 @@ class LogMessageObject extends React.Component<{ message: string }, {}> {
 class LogMessageText extends React.Component<{ className: string, ref: string, spans: ILogMessageSpan[] }, {}> {
     public render() {
         return (
-            <div className={this.props.className}>{this.props.spans.map(span => <span className={span.wasReplaced ? 'tab-logs-table-message-replaced-region' : ''}>{span.text}</span>)}</div>
+            <div className={this.props.className}>{this.props.spans.map((span, index) => <span key={index} className={span.wasReplaced ? 'tab-logs-table-message-replaced-region' : ''}>{span.text}</span>)}</div>
         );
     }
 }

--- a/src/request/components/RequestDetailPanelRequest.tsx
+++ b/src/request/components/RequestDetailPanelRequest.tsx
@@ -72,7 +72,7 @@ export class Request extends React.Component<IRequestProps, {}> {
                     {
                         panels.map(panel => {
                             return (
-                                <TabPanel header={panel.header}>
+                                <TabPanel key={panel.header} header={panel.header}>
                                     { panel.renderContent() }
                                 </TabPanel>
                             );

--- a/src/request/components/RequestDetailPanelRequestMiddleware.tsx
+++ b/src/request/components/RequestDetailPanelRequestMiddleware.tsx
@@ -52,7 +52,7 @@ export class RequestMiddleware extends React.Component<IRequestMiddlewareProps, 
 
     private renderMiddlewareRow(ordinal: number, middleware: IFlattenedMiddleware) {
         return (
-            <tr>
+            <tr key={ordinal}>
                 <td>{ordinal}</td>
                 <td>{this.renderName(middleware.middleware.name, middleware.depth)}</td>
                 <td>{middleware.middleware.packageName}</td>
@@ -76,7 +76,7 @@ export class RequestMiddleware extends React.Component<IRequestMiddlewareProps, 
             const spans = [];
 
             for (let i = 0; i < depth; i++) {
-                spans.push(<span className='tab-request-middleware-indent' />);
+                spans.push(<span key={i} className='tab-request-middleware-indent' />);
             }
 
             return spans;

--- a/src/request/components/TabPanel.tsx
+++ b/src/request/components/TabPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export class TabPanel extends React.Component<{ header: string, children? }, {}> {
+export class TabPanel extends React.Component<{ header: string, children?, key?: string }, {}> {
     public render() {
         return this.props.children;
     }

--- a/src/request/components/request-detail-panel-execution.jsx
+++ b/src/request/components/request-detail-panel-execution.jsx
@@ -209,7 +209,7 @@ var HttpRequestItemHeaderList = React.createClass({
         if (headers) {
             return (
                     <div>{_.map(headers, function(value, key) {
-                            return <DetailListItem title={key} value={value} />;
+                            return <DetailListItem key={key} title={key} value={value} />;
                         })}</div>
                 );
         }
@@ -460,7 +460,7 @@ var MiddlewareParameters = React.createClass({
 
         var paramComponents = _.map(params, function (value, key) {
             return (
-                <div className="flex tab-section-details-item">
+                <div key={key} className="flex tab-section-details-item">
                     <div className="tab-section-details-key col-2"><div className="truncate">{key}:</div></div>
                     <div className="tab-section-details-value col-8"><div className="truncate">{value}</div></div>
                 </div>
@@ -484,7 +484,7 @@ var MiddlewareHeaders = React.createClass({
 
         var headerComponents = _.map(headers, function (value) {
             return (
-                <div className="flex tab-section-details-item">
+                <div key={value.name} className="flex tab-section-details-item">
                     <div className="tab-section-details-key col-2"><div className="truncate">{value.name}:</div></div>
                     <div className="tab-section-details-value col-8"><div className="truncate">{value.values.join(', ')}</div></div>
                 </div>
@@ -515,7 +515,7 @@ var MiddlewareItem = React.createClass({
 
         if (pair.pairs.length > 0) {
             nestedComponent = pair.pairs.map(function (nestedPair){
-                return <MiddlewareItem messagePair={nestedPair} beforeExecuteCommandMessages={beforeExecuteCommandMessages} afterExecuteCommandMessages={afterExecuteCommandMessages} mongoDBMessages={mongoDBMessages} dataHttpRequestMessages={dataHttpRequestMessages} dataHttpResponseMessages={dataHttpResponseMessages} />;
+                return <MiddlewareItem key={nestedPair.startMessage.id} messagePair={nestedPair} beforeExecuteCommandMessages={beforeExecuteCommandMessages} afterExecuteCommandMessages={afterExecuteCommandMessages} mongoDBMessages={mongoDBMessages} dataHttpRequestMessages={dataHttpRequestMessages} dataHttpResponseMessages={dataHttpResponseMessages} />;
             });
         }
         else {
@@ -649,7 +649,7 @@ var MiddlewareComponents = React.createClass({
             }
 
             var generateMiddlewareItem = function (pair) {
-                return <MiddlewareItem messagePair={pair} beforeExecuteCommandMessages={beforeExecuteCommandMessages} afterExecuteCommandMessages={afterExecuteCommandMessages} mongoDBMessages={mongoDBMessages} dataHttpRequestMessages={dataHttpRequestMessages} dataHttpResponseMessages={dataHttpResponseMessages} />;
+                return <MiddlewareItem key={pair.startMessage.id} messagePair={pair} beforeExecuteCommandMessages={beforeExecuteCommandMessages} afterExecuteCommandMessages={afterExecuteCommandMessages} mongoDBMessages={mongoDBMessages} dataHttpRequestMessages={dataHttpRequestMessages} dataHttpResponseMessages={dataHttpResponseMessages} />;
             };
 
             var middlewareComponents = rootPair.pairs.map(generateMiddlewareItem);

--- a/src/request/components/request-detail-panel-generic.jsx
+++ b/src/request/components/request-detail-panel-generic.jsx
@@ -26,8 +26,8 @@ function process(data) {
 
 function processArray(data) {
     if (data.length > 0) {
-        var body = data.map(function (item) {
-            return <tr><td>{process(item)}</td></tr>;
+        var body = data.map(function (item, index) {
+            return <tr key={index}><td>{process(item)}</td></tr>;
         });
 
         return <table><thead><th>Items</th></thead><tbody>{body}</tbody></table>;

--- a/src/request/components/request-detail-panel-messages.jsx
+++ b/src/request/components/request-detail-panel-messages.jsx
@@ -17,7 +17,7 @@ module.exports = React.createClass({
                     {payload.map(function(item) { 
                         var payload = item.payload && !_.isEmpty(item.payload) ? <PanelGeneric payload={item.payload} /> : '--';
                         return (
-                            <tr className="row-devider">
+                            <tr key={item.id} className="row-devider">
                                 <td>
                                     <h2>{item.types.join(', ')} ({item.ordinal})</h2>
                                     <div>{payload}</div> 

--- a/src/request/stores/RequestStore.ts
+++ b/src/request/stores/RequestStore.ts
@@ -2,5 +2,8 @@ import { requestReducer } from '../reducers/RequestReducer';
 
 import { createStore } from 'redux';
 
-export = createStore(requestReducer,
-    DEV_TOOLS && window.devToolsExtension && window.devToolsExtension());
+const store = DEV_TOOLS && window.devToolsExtension
+    ? createStore(requestReducer, window.devToolsExtension())
+    : createStore(requestReducer);
+
+export = store;


### PR DESCRIPTION
Several minor changes to resolve errors and warnings within the F12 Tools and VS Code.

 - Resolves error related to call to `createStore()`
 - Resolves various warnings related to missing `key` attributes on arrays of React components.
 - Resolves various warnings in VS Code related to missing `eslint` and `tslint` files if using those extensions.