### PR TITLE
bumping client version to 8a

### DIFF
--- a/_temp/hud/package.json
+++ b/_temp/hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client.hud",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-alpha.8a",
   "description": "The Javascript client that acts as an in browser viewer for the various Glimpse server backends",
   "main": "dist/hud.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpse.client",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-alpha.8a",
   "description": "The JavaScript client that acts as a viewer for the various Glimpse server backends",
   "main": "dist/glimpse.js",
   "repository": {

--- a/src/lib/TelemetryClient.ts
+++ b/src/lib/TelemetryClient.ts
@@ -349,7 +349,22 @@ class TelemetryClient {
      * then the specified props will be updated.  Otherwise, a new instance will returned. 
      */
     private getShellReadyProperties(props?: IShellReadyProperties): IShellReadyProperties {
-        props = props || <IShellReadyProperties>{};
+
+        if (!props) {
+            const p: IShellReadyProperties = {
+                sessionId: undefined,
+                clientCookieID: undefined,
+                glimpseClientVersion: undefined,
+                glimpseServerVersion: undefined,
+                serverMachineId: undefined,
+                serverAppName: undefined,
+                serverOSPlatform: undefined,
+                serverOSRelease: undefined,
+                serverOSType: undefined,
+                clientIP: undefined
+            };
+            props = p;
+        }
 
         props.sessionId = this.sessionId;
         props.clientCookieID = this.clientCookieId;
@@ -362,15 +377,9 @@ class TelemetryClient {
             props.serverOSPlatform = this.telemetryConfig.serverOSPlatform;
             props.serverOSRelease = this.telemetryConfig.serverOSRelease;
             props.serverOSType = this.telemetryConfig.serverOSType;
+            props.clientIP = this.telemetryConfig.clientIP;
         }
-        else {
-            props.glimpseServerVersion = undefined;
-            props.serverMachineId = undefined;
-            props.serverAppName = undefined;
-            props.serverOSPlatform = undefined;
-            props.serverOSRelease = undefined;
-            props.serverOSType = undefined;
-        }
+
         return props;
     }
 


### PR DESCRIPTION
Wanted to get as many people as possible using the new client which has updated telemetry events.  This way we can verify the backend pipeline is working correctly.  